### PR TITLE
 Properly pass MediaStream to enableVideo/Audio hooks

### DIFF
--- a/src/app/(routes)/meeting/officehours/[roomId]/page.tsx
+++ b/src/app/(routes)/meeting/officehours/[roomId]/page.tsx
@@ -494,7 +494,7 @@ export default function Component({ params }: { params: { roomId: string } }) {
           mediaDeviceKind: "cam",
         });
         if (stream) {
-          await enableVideo(stream);
+          await enableVideo({customVideoStream:stream});
         }
       };
       changeVideo();
@@ -510,7 +510,7 @@ export default function Component({ params }: { params: { roomId: string } }) {
           mediaDeviceKind: "mic",
         });
         if (stream) {
-          enableAudio(stream);
+          enableAudio({customAudioStream:stream});
         }
       };
       changeAudio();

--- a/src/app/(routes)/meeting/session/[roomId]/page.tsx
+++ b/src/app/(routes)/meeting/session/[roomId]/page.tsx
@@ -477,7 +477,7 @@ export default function Component({ params }: { params: { roomId: string } }) {
           mediaDeviceKind: "cam",
         });
         if (stream) {
-          await enableVideo(stream);
+          await enableVideo({customVideoStream:stream});
         }
       };
       changeVideo();
@@ -493,7 +493,7 @@ export default function Component({ params }: { params: { roomId: string } }) {
           mediaDeviceKind: "mic",
         });
         if (stream) {
-          enableAudio(stream);
+          enableAudio({customAudioStream:stream});
         }
       };
       changeAudio();


### PR DESCRIPTION
This PR corrects the way MediaStream objects are passed to the enableVideo and enableAudio hooks in @huddle01/react/hooks. The previous implementation caused a TypeScript error due to incorrect argument types. This change ensures that customVideoStream and customAudioStream properties are used, resolving the type issue and ensuring the local video and audio are correctly enabled when device preferences change.