### PR TITLE
Fix Off-Chain Attestation Issue & Replace Axios with Fetch

### DIFF
--- a/src/app/api/end-call/route.ts
+++ b/src/app/api/end-call/route.ts
@@ -60,6 +60,7 @@ export async function POST(req: NextRequest, res: NextResponse) {
 
     if (meetingType === 1) {
       meetingTypeName = "session";
+      initialDelay = 4 * 1000;
     } else if (meetingType === 2) {
       meetingTypeName = "officehours";
       initialDelay = 2 * 60 * 1000;

--- a/src/app/api/get-attest-data/route.ts
+++ b/src/app/api/get-attest-data/route.ts
@@ -18,6 +18,7 @@ async function delegateAttestationOffchain(data: any) {
     body: JSON.stringify(data),
   };
 
+
   // const response = await fetchApi(`/attest-offchain`, requestOptions);
   const response = await fetch(
     `${BASE_URL}/api/attest-offchain/`,


### PR DESCRIPTION
This PR addresses the issue of off-chain attestation for participants joining a session.

- Replaced Axios with Fetch to resolve errors in off-chain attestation.
- Added a delay before calling the Huddle API to ensure participant data is retrieved correctly.